### PR TITLE
Simplify enable/disable: set storage and reload tabs; CSS handled by …

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -110,16 +110,9 @@ function initPopup(){
   $('extEnabled').addEventListener('change', e => {
     const enabled = e.target.checked;
     chrome.storage.sync.set({ enabled });
-    // (Optionnel) On (re)charge les onglets Crunchyroll pour appliquer immédiatement le changement
+    // Recharge les onglets Crunchyroll pour appliquer immédiatement
     queryCrunchyTabs(tabs => {
-      tabs.forEach(t => {
-        // Si désactivé on retire les CSS, sinon on insère à nouveau
-        if(!enabled){
-          chrome.scripting.removeCSS({target:{tabId:t.id}, files:['content.css']}, ()=>chrome.tabs.reload(t.id));
-        }else{
-          chrome.scripting.insertCSS({target:{tabId:t.id}, files:['content.css']}, ()=>chrome.tabs.reload(t.id));
-        }
-      });
+      tabs.forEach(t => chrome.tabs.reload(t.id));
     });
   });
 


### PR DESCRIPTION
…content.js
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplifies enable/disable functionality in `popup.js` by reloading tabs directly without CSS handling.
> 
>   - **Behavior**:
>     - Simplifies enable/disable functionality in `initPopup()` by reloading Crunchyroll tabs directly without handling CSS.
>   - **Code Changes**:
>     - Removes CSS insertion/removal logic from `extEnabled` event listener in `popup.js`.
>     - Directly reloads tabs in `queryCrunchyTabs` callback when extension is enabled/disabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JeremGamingYT%2FBetterCrunchyroll&utm_source=github&utm_medium=referral)<sup> for ed10a132c896bcfae9013d146c14bafbffa06014. You can [customize](https://app.ellipsis.dev/JeremGamingYT/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->