### PR TITLE
Fix popup size and CSP: widen to 420px, extract inline JS/CSS

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -8,11 +8,14 @@
   --outline:#23242a;
   --ok:#19c37d; --warn:#ffcc00; --danger:#ff5d5d;
 }
+/* Force the popup document to the desired size */
+html{ width:420px; }
 html,body{margin:0;padding:0;}
 body{
   font-family:'Inter',system-ui,Segoe UI,Arial,sans-serif;
   width:420px; /* élargi le popup */
-  max-width:100vw;
+  min-width:420px;
+  min-height:540px; /* pour éviter un popup trop bas */
   background:radial-gradient(1200px 400px at 120% -10%, rgba(255,136,51,0.20), transparent 60%), var(--bg);
   color:var(--text);
   display:flex;flex-direction:column;align-items:stretch;
@@ -71,7 +74,7 @@ input:checked + .slider:before{transform:translateX(20px)}
 .switch:focus-within .slider{outline:2px solid rgba(255,255,255,.35)}
 
 /* Range */
-input[type=range]{-webkit-appearance:none;width:200px;height:4px;background:#3a3d47;border-radius:3px;outline:none}
+input[type=range]{-webkit-appearance:none;width:220px;height:4px;background:#3a3d47;border-radius:3px;outline:none}
 input[type=range]::-webkit-slider-thumb{-webkit-appearance:none;width:14px;height:14px;border-radius:50%;background:var(--accent);cursor:pointer;box-shadow:0 0 0 2px #0b0c10 inset}
 
 /* Select & Color */


### PR DESCRIPTION
This PR fixes two issues in the extension popup: (1) Popup opened very narrow (~24x344). We now force the popup document width with html/body width and min-width/min-height to 420px, ensuring Chrome renders the popup at the intended size. (2) CSP violations due to inline scripts in popup.html. We moved inline styles and scripts into external files (popup.css and popup_ui.js). Summary of changes:
- popup.html: remove inline <style> and inline script; include popup.css and popup_ui.js.
- popup.css: extracted styles, set html/body width:420px, min-width:420px, min-height:540px.
- popup_ui.js: contains the tabs/search UI logic previously inline.
This should eliminate CSP errors and make the popup large enough to see the UI.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes popup size to 420px width and resolves CSP violations by moving inline styles/scripts to external files.
> 
>   - **Popup Size Fix**:
>     - Set `html` and `body` width to `420px` and min-height to `540px` in `popup.css` to ensure correct popup dimensions.
>   - **CSP Violations Fix**:
>     - Removed inline `<style>` and `<script>` from `popup.html`.
>     - Moved styles to `popup.css` and scripts to `popup_ui.js`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JeremGamingYT%2FBetterCrunchyroll&utm_source=github&utm_medium=referral)<sup> for affd2f9154e4b29b17e1ef029be724e132ac9a08. You can [customize](https://app.ellipsis.dev/JeremGamingYT/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->