### PR TITLE
Fix race condition on enable toggle: reload tabs after storage write

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -109,10 +109,11 @@ function initPopup(){
   // ----- Enable / Disable extension -----
   $('extEnabled').addEventListener('change', e => {
     const enabled = e.target.checked;
-    chrome.storage.sync.set({ enabled });
-    // Recharge les onglets Crunchyroll pour appliquer immédiatement
-    queryCrunchyTabs(tabs => {
-      tabs.forEach(t => chrome.tabs.reload(t.id));
+    chrome.storage.sync.set({ enabled }, () => {
+      // Recharge les onglets Crunchyroll pour appliquer immédiatement
+      queryCrunchyTabs(tabs => {
+        tabs.forEach(t => chrome.tabs.reload(t.id));
+      });
     });
   });
 


### PR DESCRIPTION
Ensure we reload Crunchyroll tabs only after chrome.storage.sync.set({enabled}) completes. This avoids a race where content scripts read old values on reload and stay disabled. Changes:
- popup.js: wrap tab reload in the set() callback for the 'extEnabled' toggle.